### PR TITLE
prevents file upload from appearing on all rr map cards #35

### DIFF
--- a/cnddb/media/js/views/components/cards/external-resource-data-preview-map.js
+++ b/cnddb/media/js/views/components/cards/external-resource-data-preview-map.js
@@ -25,6 +25,8 @@ define([
         this.draw = params.draw;
         this.map = ko.observable(params.map);
 
+        this.additionalRelatedResourceContent = ko.observable(true);
+
         this.fileData = ko.observable();
         this.fileData.subscribe(function(fileData) {
             if (!self.draw) {

--- a/cnddb/templates/views/components/related-resources-map-editor.htm
+++ b/cnddb/templates/views/components/related-resources-map-editor.htm
@@ -2,5 +2,7 @@
 {% load i18n %}
 
 {% block additional_content %}
+    <!-- ko if: ko.unwrap($data.additionalRelatedResourceContent) -->
     <external-resource-data-preview params="{fileData: self.fileData, loading: self.loading, tile: self.tile, widgets: self.widgets}" ></external-resource-data-preview>
+    <!-- /ko -->
 {% endblock additional_content %}


### PR DESCRIPTION
Adds logic to only show file upload in external resource data preview map cards.

To verify, create a new `Source` instance, and visit the `Source Location` card. Notice it now does not show the file upload. Then visit `Related Observations` and notice the file upload appears.